### PR TITLE
Suppress pmd's `UnusedImport` and `UnnecessaryParens` and allow pushing without PMD's approval

### DIFF
--- a/.githooks/pre-push.sh
+++ b/.githooks/pre-push.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-mvn verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,34 @@ on:
     branches: ["main"]
 
 jobs:
-  verify-and-artifact:
+  test-and-artifact:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          cache: maven
+      - name: Set up GNU-R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: "4.3.2"
+      - name: Run tests (no static analyses)
+        run: mvn --batch-mode --update-snapshots test
+      - run: mkdir staging && cp target/*.jar staging
+      - name: Upload snapshot as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: snapshot
+          path: target/*-SNAPSHOT.jar
+      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+      - name: Update dependency graph
+        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+
+  verify:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,15 +59,6 @@ jobs:
           r-version: "4.3.2"
       - name: Run tests and static analyses
         run: mvn --batch-mode --update-snapshots verify
-      - run: mkdir staging && cp target/*.jar staging
-      - name: Upload snapshot as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: snapshot
-          path: target/*-SNAPSHOT.jar
-      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-      - name: Update dependency graph
-        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
 
   verify-macos:
     runs-on: macos-latest

--- a/.pmd-rules.xml
+++ b/.pmd-rules.xml
@@ -25,6 +25,10 @@ under the License.
     <description>
         This is the default pmd ruleset with the following changes:
 
+        - Remove UnnecessaryImport, because it marks star imports in static members which aren't unnecessary, and
+          unused imports don't signal bugs.
+        - Remove UselessParenthesis, because we don't care and extra parentheses don't signal bugs.
+
         See https://pmd.github.io/latest/pmd_userdocs_making_rulesets.html.
 
         [0] https://raw.githubusercontent.com/apache/maven-pmd-plugin/pmd7/src/main/resources/rulesets/java/maven-pmd-plugin-default.xml
@@ -43,11 +47,9 @@ under the License.
     <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop" />
     <rule ref="category/java/codestyle.xml/TooManyStaticImports" />
     <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName" />
-    <rule ref="category/java/codestyle.xml/UnnecessaryImport" />
     <rule ref="category/java/codestyle.xml/UnnecessaryModifier" />
     <rule ref="category/java/codestyle.xml/UnnecessaryReturn" />
     <rule ref="category/java/codestyle.xml/UnnecessarySemicolon" />
-    <rule ref="category/java/codestyle.xml/UselessParentheses" />
     <rule ref="category/java/codestyle.xml/UselessQualifiedThis" />
 
     <rule ref="category/java/design.xml/CollapsibleIfStatements" />

--- a/.pmd-rules.xml
+++ b/.pmd-rules.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<ruleset name="Default Maven PMD Plugin Ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>
+        This is the default pmd ruleset with the following changes:
+
+        See https://pmd.github.io/latest/pmd_userdocs_making_rulesets.html.
+
+        [0] https://raw.githubusercontent.com/apache/maven-pmd-plugin/pmd7/src/main/resources/rulesets/java/maven-pmd-plugin-default.xml
+    </description>
+
+    <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP" />
+    <rule ref="category/java/bestpractices.xml/CheckResultSet" />
+    <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation" />
+    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
+    <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
+
+    <rule ref="category/java/codestyle.xml/EmptyControlStatement" />
+    <rule ref="category/java/codestyle.xml/ExtendsObject" />
+    <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop" />
+    <rule ref="category/java/codestyle.xml/TooManyStaticImports" />
+    <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName" />
+    <rule ref="category/java/codestyle.xml/UnnecessaryImport" />
+    <rule ref="category/java/codestyle.xml/UnnecessaryModifier" />
+    <rule ref="category/java/codestyle.xml/UnnecessaryReturn" />
+    <rule ref="category/java/codestyle.xml/UnnecessarySemicolon" />
+    <rule ref="category/java/codestyle.xml/UselessParentheses" />
+    <rule ref="category/java/codestyle.xml/UselessQualifiedThis" />
+
+    <rule ref="category/java/design.xml/CollapsibleIfStatements" />
+    <rule ref="category/java/design.xml/SimplifiedTernary" />
+    <rule ref="category/java/design.xml/UselessOverridingMethod" />
+
+    <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop" />
+    <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor" />
+    <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators" />
+    <rule ref="category/java/errorprone.xml/AvoidUsingOctalValues" />
+    <rule ref="category/java/errorprone.xml/BrokenNullCheck" />
+    <rule ref="category/java/errorprone.xml/CheckSkipResult" />
+    <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray" />
+    <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices" />
+    <rule ref="category/java/errorprone.xml/EmptyCatchBlock" />
+    <rule ref="category/java/errorprone.xml/JumbledIncrementer" />
+    <rule ref="category/java/errorprone.xml/MisplacedNullCheck" />
+    <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode" />
+    <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock" />
+    <rule ref="category/java/errorprone.xml/UnconditionalIfStatement" />
+    <rule ref="category/java/errorprone.xml/UnnecessaryConversionTemporary" />
+    <rule ref="category/java/errorprone.xml/UnusedNullCheckInEquals" />
+    <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable" />
+
+    <rule ref="category/java/multithreading.xml/AvoidThreadGroup" />
+    <rule ref="category/java/multithreading.xml/DontCallThreadRun" />
+    <rule ref="category/java/multithreading.xml/DoubleCheckedLocking" />
+
+    <rule ref="category/java/performance.xml/BigIntegerInstantiation" />
+
+</ruleset>

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,3 @@ clean:
 # Install pre-commit and pre-push hooks
 setup:
 	cp -f .githooks/pre-commit.sh .git/hooks/pre-commit
-	cp -f .githooks/pre-push.sh .git/hooks/pre-push

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
         <configuration>
           <installHooks>
             <pre-commit>.githooks/pre-commit.sh</pre-commit>
-            <pre-push>.githooks/pre-push.sh</pre-push>
           </installHooks>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -130,9 +130,6 @@
             <excludes>
               <exclude>target/**/*</exclude>
             </excludes>
-            <cleanthat>
-              <version>2.18</version>
-            </cleanthat>
             <googleJavaFormat>
               <version>1.19.2</version>
               <style>GOOGLE</style>

--- a/pom.xml
+++ b/pom.xml
@@ -218,12 +218,15 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
         <version>3.21.2</version>
-        <!-- This prevents the warning "Unable to locate Source XRef to link to - DISABLED" -->
-        <!-- If we want source-links in the `site` pmd report we need to add jxr instead, -->
-        <!-- but IDEs display their own pmd report which already has source-links -->
         <configuration>
+          <!-- This prevents the warning "Unable to locate Source XRef to link to - DISABLED" -->
+          <!-- If we want source-links in the `site` pmd report we need to add jxr instead, -->
+          <!-- but IDEs display their own pmd report which already has source-links -->
           <linkXRef>false</linkXRef>
-          <failOnViolation>false</failOnViolation>
+          <!-- Use a custom ruleset -->
+          <rulesets>
+            <ruleset>.pmd-rules.xml</ruleset>
+          </rulesets>
         </configuration>
         <!-- Use pmd 7 which supports Java 21, not whatever is provided by maven-pmd-plugin -->
         <dependencies>

--- a/src/main/java/org/prlprg/bc/Compiler.java
+++ b/src/main/java/org/prlprg/bc/Compiler.java
@@ -12,6 +12,7 @@ import javax.annotation.Nullable;
 import org.prlprg.RSession;
 import org.prlprg.bc.BcInstr.*;
 import org.prlprg.sexp.*;
+import org.prlprg.util.NotImplementedError;
 
 // FIXME: use null instead of Optional (except for return types)
 // FIXME: update the SEXP API based on the experience with this code
@@ -22,7 +23,6 @@ import org.prlprg.sexp.*;
 // TODO: 13 Assignments expressions
 // TODO: 16 Improved subset and sub-assignment handling
 // TODO: simple interpreter for the constantFoldCode
-@SuppressWarnings("PMD.UnnecessaryImport")
 public class Compiler {
   private static final Set<String> MAYBE_NSE_SYMBOLS = Set.of("bquote");
   private static final Set<String> ALLOWED_INLINES =
@@ -850,10 +850,10 @@ public class Compiler {
 
   private boolean inlineRepeat(LangSXP call) {
     var body = call.arg(0).value();
-    return inlineSimpleLoop(call, body, this::compileRepeatBody);
+    return inlineSimpleLoop(body, this::compileRepeatBody);
   }
 
-  private boolean inlineSimpleLoop(LangSXP call, SEXP body, Consumer<SEXP> cmpBody) {
+  private boolean inlineSimpleLoop(SEXP body, Consumer<SEXP> cmpBody) {
     if (canSkipLoopContext(body, true)) {
       cmpBody.accept(body);
     } else {
@@ -907,7 +907,7 @@ public class Compiler {
     var test = call.arg(0).value();
     var body = call.arg(1).value();
 
-    return inlineSimpleLoop(call, body, (b) -> compileWhileBody(call, test, b));
+    return inlineSimpleLoop(body, (b) -> compileWhileBody(call, test, b));
   }
 
   private void compileWhileBody(LangSXP call, SEXP test, SEXP body) {
@@ -1208,13 +1208,13 @@ public class Compiler {
   }
 
   private Optional<SEXP> constantFoldCall(LangSXP call) {
-    //        if (!(call.fun() instanceof RegSymSXP funSym && isFoldableFun(funSym))) {
-    //            return Optional.empty();
-    //        }
+    if (!(call.fun() instanceof RegSymSXP funSym && isFoldableFun(funSym))) {
+      return Optional.empty();
+    }
 
     // fold args -- check consts
     // do.call <- need a basic interpreter
-    return Optional.empty();
+    throw new NotImplementedError();
   }
 
   private boolean isFoldableFun(RegSymSXP sym) {


### PR DESCRIPTION
You will need to `rm .git/hooks/pre-push` to push without running `mvn verify`. The PMD tests and other static analyses will still run on GitHub actions, but it will also check tests without analyses, and let you merge regardless of whether any checks fail.